### PR TITLE
Fix Mastodon sample comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Default location: `~/.config/feedbinctl/config`
 github_tag_id = 42           # GitHub
 acme_tag_id = 99             # Acme
 x_tag_id = 1234              # X
-mastadon_tag_id = 54321      # X
+mastadon_tag_id = 54321      # Mastodon
 topic_query = '"emacs" OR "plan9" OR "rust"'
 recent_filter = 'published:>now-7d'
 social = "tag_id:{{ x_tag_id }} OR tag_id:{{ mastodon_tag_id }}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ mod tests {
 github_tag_id = "42"           # GitHub
 acme_tag_id = "99"             # Acme
 x_tag_id = "1234"              # X
-mastadon_tag_id = "54321"      # X
+mastadon_tag_id = "54321"      # Mastodon
 topic_query = '"emacs" OR "plan9" OR "rust"'
 recent_filter = 'published:>now-7d'
 social = "tag_id:{{ x_tag_id }} OR tag_id:{{ mastodon_tag_id }}"


### PR DESCRIPTION
## Summary
- fix Mastodon label in README sample config
- update inline sample config used in tests

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68451a455930832c915e11cbac4c4621