### PR TITLE
Implement Feedbin auth command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "handlebars",
  "keyring",
  "reqwest",
+ "rpassword",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -1952,6 +1953,27 @@ dependencies = [
  "getrandom 0.2.16",
  "libc",
  "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 toml_edit = { version = "0.21", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+rpassword = "7"
 
 [dev-dependencies]
 wiremock = "0.5"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Manage Feedbin [Saved Searches](https://github.com/feedbin/feedbin-api/blob/mast
 * `feedbinctl pull` - pull current Saved Searches and tags; writes tag‑ID variables into your config.
 * `feedbinctl diff` - show differences between your configuration file and Feedbin.
 * `feedbinctl push` - make Feedbin match the configuration file.
-* `feedbinctl auth login` -store your Feedbin token securely in the OS keyring.
+* `feedbinctl auth login` - store your Feedbin credentials securely in the OS keyring.
+  These credentials are used for HTTP basic authentication ("username:password").
 
 ## Installation
 

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -1,9 +1,36 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use keyring::Entry;
+use rpassword::prompt_password;
+use std::io::{self, Write};
 
 pub async fn login() -> Result<()> {
-    todo!("auth login not implemented");
+    let mut username = String::new();
+    print!("Feedbin username: ");
+    io::stdout().flush().context("failed to flush stdout")?;
+    io::stdin()
+        .read_line(&mut username)
+        .context("failed to read username")?;
+    let username = username.trim();
+
+    let password = prompt_password("Feedbin password: ")?;
+
+    let credentials = format!("{}:{}", username, password);
+    let entry = Entry::new("feedbinctl", "feedbin")
+        .context("failed to open keyring entry")?;
+    entry
+        .set_password(&credentials)
+        .context("failed to store credentials in keyring")?;
+
+    println!("Credentials stored in keyring");
+    Ok(())
 }
 
 pub async fn logout() -> Result<()> {
-    todo!("auth logout not implemented");
+    let entry = Entry::new("feedbinctl", "feedbin")
+        .context("failed to open keyring entry")?;
+    match entry.delete_password() {
+        Ok(_) => println!("Credentials removed from keyring"),
+        Err(err) => println!("No credentials found ({err})"),
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add rpassword dependency
- implement `auth login` and `auth logout`
- update README about login command

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68451c0ff8c4832cbdb926a574f241f5