### PR TITLE
Implement diff subcommand with colorized output

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -57,5 +57,6 @@ Mock HTTP with `wiremock` to keep tests offline.
 
 ## Build
 
-* Always run `cargo check`, `cargo build`, and `cargo test`.
-* Fix all warnings and errors until all three commands succeed.
+* Always run `cargo fmt --all`, `cargo check`, `cargo build`, `cargo lint` (alias
+  for `cargo clippy -- -D warnings`), and `cargo test`.
+* Fix all warnings and errors until all commands succeed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "directories",
  "handlebars",
  "keyring",
+ "owo-colors",
  "reqwest",
  "rpassword",
  "serde",
@@ -1611,6 +1612,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ keyring = "2"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 toml_edit = { version = "0.21", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 rpassword = "7"
+owo-colors = "3"
 
 [dev-dependencies]
 wiremock = "0.5"

--- a/src/cmd_auth.rs
+++ b/src/cmd_auth.rs
@@ -15,8 +15,7 @@ pub async fn login() -> Result<()> {
     let password = prompt_password("Feedbin password: ")?;
 
     let credentials = format!("{}:{}", username, password);
-    let entry = Entry::new("feedbinctl", "feedbin")
-        .context("failed to open keyring entry")?;
+    let entry = Entry::new("feedbinctl", "feedbin").context("failed to open keyring entry")?;
     entry
         .set_password(&credentials)
         .context("failed to store credentials in keyring")?;
@@ -26,8 +25,7 @@ pub async fn login() -> Result<()> {
 }
 
 pub async fn logout() -> Result<()> {
-    let entry = Entry::new("feedbinctl", "feedbin")
-        .context("failed to open keyring entry")?;
+    let entry = Entry::new("feedbinctl", "feedbin").context("failed to open keyring entry")?;
     match entry.delete_password() {
         Ok(_) => println!("Credentials removed from keyring"),
         Err(err) => println!("No credentials found ({err})"),

--- a/src/cmd_diff.rs
+++ b/src/cmd_diff.rs
@@ -1,5 +1,139 @@
-use anyhow::Result;
+use crate::cmd_pull::fetch_feedbin_config;
+use crate::config::{Config, Search};
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use handlebars::Handlebars;
+use owo_colors::OwoColorize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+#[derive(Debug, PartialEq)]
+pub enum DiffOp {
+    Create(Search),
+    Update { from: Search, to: Search },
+    Delete(Search),
+}
+
+fn resolve_searches(cfg: &Config) -> Result<BTreeMap<String, String>> {
+    let hb = Handlebars::new();
+    let mut out = BTreeMap::new();
+    for s in &cfg.searches {
+        let rendered = hb
+            .render_template(&s.query, &cfg.vars)
+            .with_context(|| format!("failed to render query for '{}'", s.name))?;
+        out.insert(s.name.clone(), rendered);
+    }
+    Ok(out)
+}
+
+pub fn diff_configs(current: &Config, desired: &Config) -> Result<Vec<DiffOp>> {
+    let cur = resolve_searches(current)?;
+    let des = resolve_searches(desired)?;
+
+    let mut ops = Vec::new();
+
+    for (name, new_q) in &des {
+        match cur.get(name) {
+            None => ops.push(DiffOp::Create(Search {
+                name: name.clone(),
+                query: new_q.clone(),
+            })),
+            Some(old_q) => {
+                if old_q != new_q {
+                    ops.push(DiffOp::Update {
+                        from: Search {
+                            name: name.clone(),
+                            query: old_q.clone(),
+                        },
+                        to: Search {
+                            name: name.clone(),
+                            query: new_q.clone(),
+                        },
+                    });
+                }
+            }
+        }
+    }
+
+    for (name, old_q) in &cur {
+        if !des.contains_key(name) {
+            ops.push(DiffOp::Delete(Search {
+                name: name.clone(),
+                query: old_q.clone(),
+            }));
+        }
+    }
+
+    Ok(ops)
+}
+
+fn config_path() -> Result<PathBuf> {
+    let proj = ProjectDirs::from("com", "feedbin", "feedbinctl")
+        .context("could not determine configuration directory")?;
+    Ok(proj.config_dir().join("config"))
+}
+
+async fn load_local_config() -> Result<Config> {
+    let path = config_path()?;
+    let data = tokio::fs::read_to_string(&path)
+        .await
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let cfg: Config = toml_edit::de::from_str(&data).context("failed to parse config file")?;
+    Ok(cfg)
+}
 
 pub async fn run() -> Result<()> {
-    todo!("diff command not implemented");
+    let desired = load_local_config().await?;
+    let current = fetch_feedbin_config().await?;
+
+    let ops = diff_configs(&current, &desired)?;
+
+    for op in ops {
+        match op {
+            DiffOp::Create(s) => println!("{} {}", "+".green(), s.name.green()),
+            DiffOp::Delete(s) => println!("{} {}", "-".red(), s.name.red()),
+            DiffOp::Update { from: _, to } => println!("{} {}", "~".yellow(), to.name.yellow()),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_basic() {
+        let mut cur = Config::default();
+        cur.vars.insert("tag".into(), "1".into());
+        cur.searches.push(Search {
+            name: "S1".into(),
+            query: "foo {{ tag }}".into(),
+        });
+        cur.searches.push(Search {
+            name: "S2".into(),
+            query: "bar".into(),
+        });
+
+        let mut des = Config::default();
+        des.vars.insert("tag".into(), "2".into());
+        des.searches.push(Search {
+            name: "S1".into(),
+            query: "foo {{ tag }}".into(),
+        });
+        des.searches.push(Search {
+            name: "S3".into(),
+            query: "baz".into(),
+        });
+
+        let ops = diff_configs(&cur, &des).unwrap();
+        assert_eq!(ops.len(), 3);
+        assert!(
+            matches!(ops[0], DiffOp::Create(_))
+                || matches!(ops[1], DiffOp::Create(_))
+                || matches!(ops[2], DiffOp::Create(_))
+        );
+        assert!(ops.iter().any(|o| matches!(o, DiffOp::Update { .. })));
+        assert!(ops.iter().any(|o| matches!(o, DiffOp::Delete(_))));
+    }
 }

--- a/src/cmd_pull.rs
+++ b/src/cmd_pull.rs
@@ -33,12 +33,12 @@ fn tag_var_name(name: &str) -> String {
     out
 }
 
-pub async fn run() -> Result<()> {
+pub async fn fetch_feedbin_config() -> Result<Config> {
     let token = match std::env::var("FEEDBIN_TOKEN") {
         Ok(t) => t,
         Err(_) => {
-            let entry = Entry::new("feedbinctl", "feedbin")
-                .context("failed to open keyring entry")?;
+            let entry =
+                Entry::new("feedbinctl", "feedbin").context("failed to open keyring entry")?;
             entry
                 .get_password()
                 .context("FEEDBIN_TOKEN not set and failed to read credentials from keyring")?
@@ -94,6 +94,12 @@ pub async fn run() -> Result<()> {
         .collect();
 
     let config = Config { vars, searches };
+
+    Ok(config)
+}
+
+pub async fn run() -> Result<()> {
+    let config = fetch_feedbin_config().await?;
 
     fn sq(s: &str) -> String {
         format!("'{}'", s.replace('\'', "''"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,6 @@ pub struct Search {
 mod tests {
     use super::*;
 
-
     const SAMPLE_CONFIG: &str = r#"
 # feedbinctl configuration
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod cli;
-mod config;
-mod cmd_pull;
-mod cmd_diff;
-mod cmd_push;
 mod cmd_auth;
+mod cmd_diff;
+mod cmd_pull;
+mod cmd_push;
+mod config;
 
 use anyhow::Result;
 use clap::Parser;


### PR DESCRIPTION
## Summary
- add clippy/lint instructions to AGENT
- enable tokio `fs` feature and add `owo-colors`
- factor out `fetch_feedbin_config` from `pull`
- implement `diff` subcommand and diff planner
- colorize diff output and test diff logic

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68464c4a5770832ca50b0ad56fabf0b5