### PR TITLE
Add sync command and improve pull substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Manage Feedbin [Saved Searches](https://github.com/feedbin/feedbin-api/blob/mast
 ## Commands
 
 * `feedbinctl pull` - pull current Saved Searches and tags; writes tag‑ID variables into your config.
+* `feedbinctl sync` - pull from Feedbin and merge into your config file.
 * `feedbinctl diff` - show differences between your configuration file and Feedbin.
 * `feedbinctl push` - make Feedbin match the configuration file.
 * `feedbinctl auth login` - store your Feedbin credentials securely in the OS keyring.
@@ -63,6 +64,9 @@ emacs ~/.config/feedbinctl/config
 
 # Preview changes
 feedbinctl diff
+
+# Refresh configuration with current Feedbin state
+feedbinctl sync
 
 # Apply when ready
 feedbinctl push

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,8 @@ pub struct Cli {
 pub enum Commands {
     /// Fetch saved searches and tags
     Pull,
+    /// Fetch and merge into config file
+    Sync,
     /// Display planned changes between config and Feedbin
     Diff,
     /// Apply changes to Feedbin

--- a/src/cmd_sync.rs
+++ b/src/cmd_sync.rs
@@ -1,0 +1,21 @@
+use crate::cmd_pull::fetch_feedbin_config_with_tags;
+use crate::config_file::{config_path, load_local_config, save_config};
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+pub async fn run() -> Result<()> {
+    let existing = load_local_config().await?.unwrap_or_default();
+    let (mut pulled, _tags) = fetch_feedbin_config_with_tags(Some(&existing.vars)).await?;
+
+    let mut vars: BTreeMap<String, String> = existing
+        .vars
+        .into_iter()
+        .filter(|(k, _)| !pulled.vars.contains_key(k))
+        .collect();
+    vars.extend(pulled.vars.into_iter());
+
+    pulled.vars = vars;
+    save_config(&pulled).await?;
+    println!("Wrote {}", config_path()?.display());
+    Ok(())
+}

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,0 +1,43 @@
+use crate::config::Config;
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+pub fn config_path() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(dir).join("feedbinctl").join("config"));
+    }
+
+    let home = std::env::var("HOME")
+        .map(PathBuf::from)
+        .context("could not determine home directory")?;
+    Ok(home.join(".config").join("feedbinctl").join("config"))
+}
+
+pub async fn load_local_config() -> Result<Option<Config>> {
+    let path = config_path()?;
+    let data = match tokio::fs::read_to_string(&path).await {
+        Ok(d) => d,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+    let cfg: Config = toml_edit::de::from_str(&data).context("failed to parse config file")?;
+    Ok(Some(cfg))
+}
+
+pub async fn save_config(cfg: &Config) -> Result<()> {
+    let path = config_path()?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let data = toml_edit::ser::to_string_pretty(cfg).context("failed to serialise config")?;
+    tokio::fs::write(&path, data)
+        .await
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ mod cmd_auth;
 mod cmd_diff;
 mod cmd_pull;
 mod cmd_push;
+mod cmd_sync;
 mod config;
+mod config_file;
 
 use anyhow::Result;
 use clap::Parser;
@@ -15,6 +17,7 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Pull => cmd_pull::run().await,
+        Commands::Sync => cmd_sync::run().await,
         Commands::Diff => cmd_diff::run().await,
         Commands::Push => cmd_push::run().await,
         Commands::Auth(auth_cmd) => match auth_cmd {


### PR DESCRIPTION
## Summary
- add `sync` command to merge pulled searches into config
- extract config file helpers
- reuse local variables when substituting queries
- document new command and workflow

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6847c70ded50832caba94368853a983e